### PR TITLE
Fix multiple issues with v1.8+ login sequence

### DIFF
--- a/hotline/client_conn.go
+++ b/hotline/client_conn.go
@@ -37,6 +37,7 @@ type ClientConn struct {
 	Idle       bool
 	AutoReply  *[]byte
 	Transfers  map[int][]*FileTransfer
+	Agreed     bool
 }
 
 func (cc *ClientConn) sendAll(t int, fields ...Field) {
@@ -168,7 +169,7 @@ func (cc ClientConn) Disconnect() {
 // NotifyOthers sends transaction t to other clients connected to the server
 func (cc ClientConn) NotifyOthers(t Transaction) {
 	for _, c := range sortedClients(cc.Server.Clients) {
-		if c.ID != cc.ID {
+		if c.ID != cc.ID && c.Agreed {
 			t.clientID = c.ID
 			cc.Server.outbox <- t
 		}

--- a/hotline/transaction_handlers.go
+++ b/hotline/transaction_handlers.go
@@ -821,11 +821,8 @@ func (cc *ClientConn) notifyNewUserHasJoined() (res []Transaction, err error) {
 }
 
 func HandleTranAgreed(cc *ClientConn, t *Transaction) (res []Transaction, err error) {
-	bs := make([]byte, 2)
-	binary.BigEndian.PutUint16(bs, *cc.Server.NextGuestID)
-
+	cc.Agreed = true
 	cc.UserName = t.GetField(fieldUserName).Data
-	*cc.ID = bs
 	*cc.Icon = t.GetField(fieldUserIconID).Data
 
 	options := t.GetField(fieldOptions).Data

--- a/hotline/transaction_handlers_test.go
+++ b/hotline/transaction_handlers_test.go
@@ -5,7 +5,6 @@ import (
 	"io/fs"
 	"math/rand"
 	"os"
-	"reflect"
 	"testing"
 )
 
@@ -227,12 +226,21 @@ func TestHandleGetUserNameList(t *testing.T) {
 								Icon:     &[]byte{0, 2},
 								Flags:    &[]byte{0, 3},
 								UserName: []byte{0, 4},
+								Agreed:   true,
 							},
 							uint16(2): {
 								ID:       &[]byte{0, 2},
 								Icon:     &[]byte{0, 2},
 								Flags:    &[]byte{0, 3},
 								UserName: []byte{0, 4},
+								Agreed:   true,
+							},
+							uint16(3): {
+								ID:       &[]byte{0, 3},
+								Icon:     &[]byte{0, 2},
+								Flags:    &[]byte{0, 3},
+								UserName: []byte{0, 4},
+								Agreed:   false,
 							},
 						},
 					},
@@ -272,9 +280,7 @@ func TestHandleGetUserNameList(t *testing.T) {
 				t.Errorf("HandleGetUserNameList() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("HandleGetUserNameList() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
Squashed bugs:
* A v1.8+ user that has connected but not agreed will show up in chat and the userlist as a blank user name
* Race condition where a v1.8+ user in connected but not agreed state duplicated the ID of the next user to connect
* A v1.8+ user that is connected but not agreed will receive the user list