### PR TITLE
Implement user ban

### DIFF
--- a/hotline/ban.go
+++ b/hotline/ban.go
@@ -1,0 +1,5 @@
+package hotline
+
+import "time"
+
+const tempBanDuration = 30 * time.Minute

--- a/hotline/field.go
+++ b/hotline/field.go
@@ -19,7 +19,7 @@ const fieldUserAccess = 110
 
 // const fieldUserAlias = 111 TODO: implement
 const fieldUserFlags = 112
-const fieldOptions = 113
+const fieldOptions = 113 // Server message (1) or admin message (any other value)
 const fieldChatID = 114
 const fieldChatSubject = 115
 const fieldWaitingCount = 116


### PR DESCRIPTION
It's unlikely this feature will see much use, but in the interest of having full feature parity with the official software and in having a way to somewhat mitigate any bad actors, I've implemented temporary and permanent user banning by client IP.  Also it was fun!

Temp bans are 30 minutes to match the official software behavior.

Example `Banlist.yaml`, where IP is banned until time.  A nil time indicates permanent ban.
```
192.168.86.31: 2022-06-24T16:37:00.755689-07:00
192.168.86.32: nil
```

Fixes #28 