### PR TITLE
Implement "Can use any name" permission

### DIFF
--- a/hotline/access.go
+++ b/hotline/access.go
@@ -33,7 +33,7 @@ const (
 	accessCannotBeDiscon = 23
 	accessGetClientInfo  = 24
 	accessUploadAnywhere = 25
-	// accessAnyName          = 26
+	accessAnyName        = 26
 	// accessNoAgreement      = 27
 	accessSetFileComment   = 28
 	accessSetFolderComment = 29

--- a/hotline/field.go
+++ b/hotline/field.go
@@ -19,7 +19,7 @@ const fieldUserAccess = 110
 
 // const fieldUserAlias = 111 TODO: implement
 const fieldUserFlags = 112
-const fieldOptions = 113 // Server message (1) or admin message (any other value)
+const fieldOptions = 113
 const fieldChatID = 114
 const fieldChatSubject = 115
 const fieldWaitingCount = 116

--- a/hotline/server.go
+++ b/hotline/server.go
@@ -627,7 +627,11 @@ func (s *Server) handleNewConnection(ctx context.Context, rwc io.ReadWriteCloser
 	}
 
 	if clientLogin.GetField(fieldUserName).Data != nil {
-		c.UserName = clientLogin.GetField(fieldUserName).Data
+		if c.Authorize(accessAnyName) {
+			c.UserName = clientLogin.GetField(fieldUserName).Data
+		} else {
+			c.UserName = []byte(c.Account.Name)
+		}
 	}
 
 	if clientLogin.GetField(fieldUserIconID).Data != nil {


### PR DESCRIPTION
This implements the "Can use any name" permission.  If this permission is disabled, the client username is forced to match the username of the account.

<img width="297" alt="Screen Shot 2022-06-24 at 6 46 01 PM" src="https://user-images.githubusercontent.com/868228/175753638-5323a3dd-7975-4f12-a424-5cc010ded2a3.png">

Fixes #2
