### PR TITLE
Add config option to specify ignored filename patterns

### DIFF
--- a/cmd/mobius-hotline-server/mobius/config/config.yaml
+++ b/cmd/mobius-hotline-server/mobius/config/config.yaml
@@ -19,8 +19,8 @@ EnableTrackerRegistration: false
 
 # List of trackers to register with
 Trackers:
-- hltracker.com:5499
-- tracker.preterhuman.net:5499
+  - hltracker.com:5499
+  - tracker.preterhuman.net:5499
 
 # Preserve resource forks and file type/creator codes for files uploaded by Macintosh clients.
 # This comes with trade-offs.  For more details, see:
@@ -42,3 +42,8 @@ MaxDownloadsPerClient: 0
 
 # Maximum simultaneous connections/IP; currently unimplemented
 MaxConnectionsPerIP: 0
+
+# List of Regular Expression filters for the Files list
+IgnoreFiles:
+  - '^\.*'     # Ignore all files starting with ".".  Leave this set if you are using the PreserveResourceForks option.
+  - '^@'       # Ignore all files starting with "@"

--- a/hotline/config.go
+++ b/hotline/config.go
@@ -13,4 +13,5 @@ type Config struct {
 	MaxDownloadsPerClient     int      `yaml:"MaxDownloadsPerClient"`                   // Per client simultaneous download limit
 	MaxConnectionsPerIP       int      `yaml:"MaxConnectionsPerIP"`                     // Max connections per IP
 	PreserveResourceForks     bool     `yaml:"PreserveResourceForks"`                   // Enable preservation of file info and resource forks in sidecar files
+	IgnoreFiles               []string `yaml:"IgnoreFiles"`                             // List of regular expression for filtering files from the file list
 }

--- a/hotline/transaction_handlers.go
+++ b/hotline/transaction_handlers.go
@@ -1668,7 +1668,7 @@ func HandleGetFileNameList(cc *ClientConn, t *Transaction) (res []Transaction, e
 		return res, err
 	}
 
-	fileNames, err := getFileNameList(fullPath)
+	fileNames, err := getFileNameList(fullPath, cc.Server.Config.IgnoreFiles)
 	if err != nil {
 		return res, err
 	}


### PR DESCRIPTION
This adds a new config file option named "IgnoreFiles" with the following defaults:

```
# List of Regular Expression filters for the Files list
IgnoreFiles:
  - '^\.*'     # Ignore all files starting with ".".  Leave this set if you are using the PreserveResourceForks option.
  - '^@'       # Ignore all files starting with "@"
```

Users can add arbitrary new regex patterns if they wish.

Fixes #44