### PR TITLE
Implement access controls for threaded news item deletion

### DIFF
--- a/hotline/news.go
+++ b/hotline/news.go
@@ -202,6 +202,7 @@ func (newscat *NewsCategoryListData15) nameLen() []byte {
 	return []byte{uint8(len(newscat.Name))}
 }
 
+// TODO: re-implement as bufio.Scanner interface
 func ReadNewsPath(newsPath []byte) []string {
 	if len(newsPath) == 0 {
 		return []string{}


### PR DESCRIPTION
This implements access controls for HandleDelNewsItem, which is called when a threaded news client issues a delete for a Category or Bundle.