### PR TITLE
Add error message handling to client

### DIFF
--- a/hotline/transaction.go
+++ b/hotline/transaction.go
@@ -1,6 +1,7 @@
 package hotline
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -237,4 +238,8 @@ func (t *Transaction) GetField(id int) Field {
 	}
 
 	return Field{}
+}
+
+func (t *Transaction) IsError() bool {
+	return bytes.Compare(t.ErrorCode, []byte{0, 0, 0, 1}) == 0
 }


### PR DESCRIPTION
Add display of error messages sent from server to client, which fixes a client crash that happens when if the client tries to view a Drop Box without the necessary permission.  This is a starting point for further error response handling/display.