### PR TITLE
Add basic stat counters

### DIFF
--- a/cmd/mobius-hotline-server/main.go
+++ b/cmd/mobius-hotline-server/main.go
@@ -118,7 +118,7 @@ type statHandler struct {
 }
 
 func (sh *statHandler) RenderStats(w http.ResponseWriter, _ *http.Request) {
-	u, err := json.Marshal(sh.hlServer.Stats)
+	u, err := json.Marshal(sh.hlServer.CurrentStats())
 	if err != nil {
 		panic(err)
 	}

--- a/hotline/stats.go
+++ b/hotline/stats.go
@@ -8,10 +8,10 @@ type Stats struct {
 	CurrentlyConnected  int
 	DownloadsInProgress int
 	UploadsInProgress   int
+	WaitingDownloads    int
 	ConnectionPeak      int
+	ConnectionCounter   int
 	DownloadCounter     int
 	UploadCounter       int
-
-	LoginCount int       `yaml:"login count"`
-	StartTime  time.Time `yaml:"start time"`
+	Since               time.Time
 }


### PR DESCRIPTION
This adds basic stat counters equivalent to the Hotline Server 1.9.2 stats:

<img width="265" alt="Screen Shot 2022-07-04 at 2 21 40 PM" src="https://user-images.githubusercontent.com/868228/177217568-966c6857-33b0-4ea5-9664-8dc7ff1aeab1.png">

The Mobius stat counters are available when the server is run with the optional `--stats-port` command line argument.

Example output when the server is run with: `--stats-port=5603`:

``` 
curl -s localhost:5603 | jq .           
{
  "CurrentlyConnected": 0,
  "DownloadsInProgress": 0,
  "UploadsInProgress": 0,
  "WaitingDownloads": 0,
  "ConnectionPeak": 0,
  "ConnectionCounter": 0,
  "DownloadCounter": 0,
  "UploadCounter": 0,
  "Since": "2022-07-04T14:18:27.473286-07:00"
}
```

Note: WaitingDownloads is currently unimplemented (#61)

Related to #29