### PR TITLE
Register with Gloarbline 1.9.7 client default trackers

### DIFF
--- a/cmd/mobius-hotline-server/mobius/config/config.yaml
+++ b/cmd/mobius-hotline-server/mobius/config/config.yaml
@@ -21,6 +21,8 @@ EnableTrackerRegistration: false
 Trackers:
   - hltracker.com:5499
   - tracker.preterhuman.net:5499
+  - saddle.dyndns.org:5499
+  - hotline.kicks-ass.net:5499
 
 # Preserve resource forks and file type/creator codes for files uploaded by Macintosh clients.
 # This comes with trade-offs.  For more details, see:


### PR DESCRIPTION
Update the default config to register with trackers from the Gloarbline 1.9.7 client that are still active.