### PR TITLE
Improve Frogblast client compatibility

### DIFF
--- a/hotline/server.go
+++ b/hotline/server.go
@@ -34,6 +34,7 @@ type requestCtx struct {
 }
 
 var nostalgiaVersion = []byte{0, 0, 2, 0x2c} // version ID used by the Nostalgia client
+var frogblastVersion = []byte{0, 0, 0, 0xb9} // version ID used by the Frogblast 1.2.4 client
 
 type Server struct {
 	Port          int
@@ -667,7 +668,7 @@ func (s *Server) handleNewConnection(ctx context.Context, rwc io.ReadWriteCloser
 	}
 
 	// Used simplified hotline v1.2.3 login flow for clients that do not send login info in tranAgreed
-	if c.Version == nil || bytes.Equal(c.Version, nostalgiaVersion) {
+	if c.Version == nil || bytes.Equal(c.Version, nostalgiaVersion) || bytes.Equal(c.Version, frogblastVersion) {
 		c.Agreed = true
 		c.logger = c.logger.With("name", string(c.UserName))
 		c.logger.Infow("Login successful", "clientVersion", fmt.Sprintf("%v", func() int { i, _ := byteToInt(c.Version); return i }()))

--- a/hotline/transaction_handlers.go
+++ b/hotline/transaction_handlers.go
@@ -253,9 +253,10 @@ func HandleChatSend(cc *ClientConn, t *Transaction) (res []Transaction, err erro
 		formattedMsg = fmt.Sprintf("\r*** %s %s", cc.UserName, t.GetField(fieldData).Data)
 	}
 
+	// The ChatID field is used to identify messages as belonging to a private chat.
+	// All clients *except* Frogblast omit this field for public chat, but Frogblast sends a value of 00 00 00 00.
 	chatID := t.GetField(fieldChatID).Data
-	// a non-nil chatID indicates the message belongs to a private chat
-	if chatID != nil {
+	if chatID != nil && !bytes.Equal([]byte{0, 0, 0, 0}, chatID) {
 		chatInt := binary.BigEndian.Uint32(chatID)
 		privChat := cc.Server.PrivateChats[chatInt]
 


### PR DESCRIPTION
This change fixes two Frogblast compatibility issues:

1. Frogblast does not seem to follow the HL 1.5+ login/agreement flow, so I've made clients identifying as version `0xb9` go down the 1.2.3 path instead.  
2. Frogblast sends a ChatID field value of `00 00 00 00` for public chat, which seems unique to this client.  I'd added a check for this.

Tested in OS X 10.4 running in Qemu.

Fixes #72