### PR TITLE
Fix mutex deadlock bug on invalid client

### DIFF
--- a/hotline/server.go
+++ b/hotline/server.go
@@ -152,12 +152,11 @@ func (s *Server) sendTransaction(t Transaction) error {
 	}
 
 	s.mux.Lock()
+	defer s.mux.Unlock()
 	client := s.Clients[uint16(clientID)]
 	if client == nil {
 		return fmt.Errorf("invalid client id %v", *t.clientID)
 	}
-
-	s.mux.Unlock()
 
 	b, err := t.MarshalBinary()
 	if err != nil {


### PR DESCRIPTION
This fixes a bug where locked mutex is never unlocked if sendTransaction returns `invalid client id error`.  

TODO: revisit mutex vs channels