### PR TITLE
Add option to trigger terminal bell for chat messages

### DIFF
--- a/hotline/client.go
+++ b/hotline/client.go
@@ -35,10 +35,11 @@ type Bookmark struct {
 }
 
 type ClientPrefs struct {
-	Username  string     `yaml:"Username"`
-	IconID    int        `yaml:"IconID"`
-	Bookmarks []Bookmark `yaml:"Bookmarks"`
-	Tracker   string     `yaml:"Tracker"`
+	Username   string     `yaml:"Username"`
+	IconID     int        `yaml:"IconID"`
+	Bookmarks  []Bookmark `yaml:"Bookmarks"`
+	Tracker    string     `yaml:"Tracker"`
+	EnableBell bool       `yaml:"EnableBell"`
 }
 
 func (cp *ClientPrefs) IconBytes() []byte {
@@ -466,6 +467,10 @@ func (c *Client) renderUserList() {
 }
 
 func handleClientChatMsg(c *Client, t *Transaction) (res []Transaction, err error) {
+	if c.pref.EnableBell {
+		fmt.Println("\a")
+	}
+
 	_, _ = fmt.Fprintf(c.UI.chatBox, "%s \n", t.GetField(fieldData).Data)
 
 	return res, err

--- a/hotline/ui.go
+++ b/hotline/ui.go
@@ -145,6 +145,7 @@ func (ui *UI) renderSettingsForm() *tview.Flex {
 		return err == nil
 	}, nil)
 	settingsForm.AddInputField("Tracker", ui.HLClient.pref.Tracker, 0, nil, nil)
+	settingsForm.AddCheckbox("Enable Terminal Bell", ui.HLClient.pref.EnableBell, nil)
 	settingsForm.AddButton("Save", func() {
 		usernameInput := settingsForm.GetFormItem(0).(*tview.InputField).GetText()
 		if len(usernameInput) == 0 {
@@ -154,6 +155,7 @@ func (ui *UI) renderSettingsForm() *tview.Flex {
 		iconStr = settingsForm.GetFormItem(1).(*tview.InputField).GetText()
 		ui.HLClient.pref.IconID, _ = strconv.Atoi(iconStr)
 		ui.HLClient.pref.Tracker = settingsForm.GetFormItem(2).(*tview.InputField).GetText()
+		ui.HLClient.pref.EnableBell = settingsForm.GetFormItem(3).(*tview.Checkbox).IsChecked()
 
 		out, err := yaml.Marshal(&ui.HLClient.pref)
 		if err != nil {


### PR DESCRIPTION
This adds an optional user setting to trigger the terminal bell on receipt of a chat message

<img width="787" alt="Screenshot 2022-12-01 at 2 13 40 PM" src="https://user-images.githubusercontent.com/868228/205170292-c828208b-bff1-4e68-a891-40666d4a7514.png">
