### PR TITLE
Improve compatibility with Obsession client

### DIFF
--- a/hotline/server.go
+++ b/hotline/server.go
@@ -36,6 +36,8 @@ type requestCtx struct {
 var nostalgiaVersion = []byte{0, 0, 2, 0x2c} // version ID used by the Nostalgia client
 var frogblastVersion = []byte{0, 0, 0, 0xb9} // version ID used by the Frogblast 1.2.4 client
 
+var obsessionVersion = []byte{0xbe, 0x00} // version ID used by the Obsession client
+
 type Server struct {
 	Port          int
 	Accounts      map[string]*Account
@@ -673,7 +675,8 @@ func (s *Server) handleNewConnection(ctx context.Context, rwc io.ReadWriteCloser
 	}
 
 	// Used simplified hotline v1.2.3 login flow for clients that do not send login info in tranAgreed
-	if c.Version == nil || bytes.Equal(c.Version, nostalgiaVersion) || bytes.Equal(c.Version, frogblastVersion) {
+	// TODO: figure out a generalized solution that doesn't require playing whack-a-mole for specific client versions
+	if c.Version == nil || bytes.Equal(c.Version, nostalgiaVersion) || bytes.Equal(c.Version, frogblastVersion) || bytes.Equal(c.Version, obsessionVersion) {
 		c.Agreed = true
 		c.logger = c.logger.With("name", string(c.UserName))
 		c.logger.Infow("Login successful", "clientVersion", fmt.Sprintf("%v", func() int { i, _ := byteToInt(c.Version); return i }()))


### PR DESCRIPTION
This appears to fix issue #84 for the Obsession client.  The fix was to add it to the growing list of known clients that use the old 1.2.3 login behavior instead of the 1.5+ behavior.  

I need to revisit and figure out a better solution -- maybe flip this around and assume that all clients use 1.2.3 behavior unless a known 1.5+ version is provided.

Tested with Obsession Hotline Client 109.2
