### PR TITLE
Fix threaded news bugs

### DIFF
--- a/hotline/news.go
+++ b/hotline/news.go
@@ -52,6 +52,7 @@ func (newscat *NewsCategoryListData15) GetNewsArtListData() NewsArtListData {
 
 	nald := NewsArtListData{
 		ID:          []byte{0, 0, 0, 0},
+		Count:       len(newsArts),
 		Name:        []byte{},
 		Description: []byte{},
 		NewsArtList: newsArtsPayload,
@@ -85,11 +86,12 @@ type NewsArtListData struct {
 	Name        []byte `yaml:"Name"`
 	Description []byte `yaml:"Description"` // not used?
 	NewsArtList []byte // List of articles			Optional (if article count > 0)
+	Count       int
 }
 
 func (nald *NewsArtListData) Payload() []byte {
 	count := make([]byte, 4)
-	binary.BigEndian.PutUint32(count, uint32(len(nald.NewsArtList)))
+	binary.BigEndian.PutUint32(count, uint32(nald.Count))
 
 	out := append(nald.ID, count...)
 	out = append(out, []byte{uint8(len(nald.Name))}...)

--- a/hotline/server.go
+++ b/hotline/server.go
@@ -36,6 +36,8 @@ type requestCtx struct {
 var nostalgiaVersion = []byte{0, 0, 2, 0x2c} // version ID used by the Nostalgia client
 var frogblastVersion = []byte{0, 0, 0, 0xb9} // version ID used by the Frogblast 1.2.4 client
 
+var heildrun = []byte{0, 0x97}
+
 var obsessionVersion = []byte{0xbe, 0x00} // version ID used by the Obsession client
 
 type Server struct {
@@ -676,7 +678,7 @@ func (s *Server) handleNewConnection(ctx context.Context, rwc io.ReadWriteCloser
 
 	// Used simplified hotline v1.2.3 login flow for clients that do not send login info in tranAgreed
 	// TODO: figure out a generalized solution that doesn't require playing whack-a-mole for specific client versions
-	if c.Version == nil || bytes.Equal(c.Version, nostalgiaVersion) || bytes.Equal(c.Version, frogblastVersion) || bytes.Equal(c.Version, obsessionVersion) {
+	if c.Version == nil || bytes.Equal(c.Version, nostalgiaVersion) || bytes.Equal(c.Version, frogblastVersion) || bytes.Equal(c.Version, obsessionVersion) || bytes.Equal(c.Version, heildrun) {
 		c.Agreed = true
 		c.logger = c.logger.With("name", string(c.UserName))
 		c.logger.Infow("Login successful", "clientVersion", fmt.Sprintf("%v", func() int { i, _ := byteToInt(c.Version); return i }()))

--- a/hotline/util.go
+++ b/hotline/util.go
@@ -1,0 +1,17 @@
+package hotline
+
+import (
+	"encoding/binary"
+	"errors"
+)
+
+func byteToInt(bytes []byte) (int, error) {
+	switch len(bytes) {
+	case 2:
+		return int(binary.BigEndian.Uint16(bytes)), nil
+	case 4:
+		return int(binary.BigEndian.Uint32(bytes)), nil
+	}
+
+	return 0, errors.New("unknown byte length")
+}

--- a/hotline/util_test.go
+++ b/hotline/util_test.go
@@ -1,0 +1,47 @@
+package hotline
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_byteToInt(t *testing.T) {
+	type args struct {
+		bytes []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    int
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "with 2 bytes of input",
+			args:    args{bytes: []byte{0, 1}},
+			want:    1,
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "with 4 bytes of input",
+			args:    args{bytes: []byte{0, 1, 0, 0}},
+			want:    65536,
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "with invalid number of bytes of input",
+			args:    args{bytes: []byte{1, 0, 0, 0, 0, 0, 0, 0}},
+			want:    0,
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := byteToInt(tt.args.bytes)
+			if !tt.wantErr(t, err, fmt.Sprintf("byteToInt(%v)", tt.args.bytes)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "byteToInt(%v)", tt.args.bytes)
+		})
+	}
+}


### PR DESCRIPTION
1. Fix handling of article IDs sent as 4 bytes instead of 2
2. Fix incorrect article count listing that strangely only affects third party clients

Related #87