### PR TITLE
Fix bug in news article reply threading

### DIFF
--- a/hotline/transaction_handlers.go
+++ b/hotline/transaction_handlers.go
@@ -1357,7 +1357,7 @@ func HandlePostNewsArt(cc *ClientConn, t *Transaction) (res []Transaction, err e
 	}
 	convertedArtID := uint32(artID)
 	bs := make([]byte, 4)
-	binary.LittleEndian.PutUint32(bs, convertedArtID)
+	binary.BigEndian.PutUint32(bs, convertedArtID)
 
 	newArt := NewsArtData{
 		Title:         string(t.GetField(fieldNewsArtTitle).Data),


### PR DESCRIPTION
This fixes a bug introduced in 0.10.15 where threaded news replies are not correctly threaded under the parent news post