### PR TITLE
Handle tracker list errors

### DIFF
--- a/hotline/tracker_test.go
+++ b/hotline/tracker_test.go
@@ -139,6 +139,44 @@ func Test_serverScanner(t *testing.T) {
 			wantToken:   []byte(nil),
 			wantErr:     assert.NoError,
 		},
+		{
+			name: "when nameLen exceeds provided data",
+			args: args{
+				data: []byte{
+					0x18, 0x05, 0x30, 0x63, // IP Addr
+					0x15, 0x7c, // Port
+					0x00, 0x02, // UserCount
+					0x00, 0x00, // ??
+					0xff,             // Name Len
+					0x54, 0x68, 0x65, // Name
+					0x03,             // Desc Len
+					0x54, 0x54, 0x54, // Description
+				},
+				atEOF: false,
+			},
+			wantAdvance: 0,
+			wantToken:   []byte(nil),
+			wantErr:     assert.NoError,
+		},
+		{
+			name: "when description len exceeds provided data",
+			args: args{
+				data: []byte{
+					0x18, 0x05, 0x30, 0x63, // IP Addr
+					0x15, 0x7c, // Port
+					0x00, 0x02, // UserCount
+					0x00, 0x00, // ??
+					0x03,             // Name Len
+					0x54, 0x68, 0x65, // Name
+					0xff,             // Desc Len
+					0x54, 0x54, 0x54, // Description
+				},
+				atEOF: false,
+			},
+			wantAdvance: 0,
+			wantToken:   []byte(nil),
+			wantErr:     assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Handle errors when fetching servers from the tracker list and present and error modal instead of panicking:

<img width="984" alt="Screenshot 2023-05-28 at 9 32 26 AM" src="https://github.com/jhalter/mobius/assets/868228/0aea2374-6162-4700-acb5-ffcdad282813">

Fixes #102