### PR TITLE
No run as root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ build
 dist/*
 
 *log
+
+# Ignore the bind mounted config directory
+config/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,18 @@ COPY . .
 
 RUN CGO_ENABLED=0 go build -o /app/server cmd/mobius-hotline-server/main.go && chmod a+x /app/server
 
-FROM scratch
+FROM debian:stable-slim
+
+# Change these as you see fit. This makes bind mounting easier so you don't have to edit bind mounted config files as root.
+ARG USERNAME=mobius
+ARG UID=1001
+ARG GUID=1001
 
 COPY --from=builder /app/server /app/server
 COPY --from=builder /app/cmd/mobius-hotline-server/mobius/config /usr/local/var/mobius/config
-
+RUN useradd -d /app -u ${UID} ${USERNAME}
+RUN chown -R ${USERNAME}:${USERNAME} /app
 EXPOSE 5500 5501
 
+USER ${USERNAME}
 ENTRYPOINT ["/app/server"]
-CMD ["/app/server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  mobius-hotline-server:
+    build: .
+    ports:
+      - "5500:5500"
+      - "5501:5501"
+    # If you intend to bind mount the config directory run
+    # cp -r cmd/mobius-hotline-server/mobius/config ./config
+    # first.
+    # volumes:
+    #   - ./config:/usr/local/var/mobius/config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
       - "5501:5501"
     # If you intend to bind mount the config directory run
     # cp -r cmd/mobius-hotline-server/mobius/config ./config
-    # first.
-    # volumes:
-    #   - ./config:/usr/local/var/mobius/config
+    # first. Otherwise, comment the line below to use the default settings.
+    volumes:
+      - ./config:/usr/local/var/mobius/config


### PR DESCRIPTION
Hi there!

Thank you so much for creating Mobius! I'm setting up my own instances and made some contributions that I hope you find useful. Among them are:

- Not running /app/server as root. With Docker, root in the container has the same privileges as root on the host which is a security risk.
- Added a docker-compose.yml file for easier building/deployment
- Updated the .gitignore file to ignore the config directory which can be bind mounted.

Please let me know if you would like to see any changes to this to make this PR acceptable. Thanks again!