### PR TITLE
Making it so the container restarts on host reboot

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   mobius-hotline-server:
     build: .
+    restart: always
     ports:
       - "5500:5500"
       - "5501:5501"


### PR DESCRIPTION
One more. After running `docker compose up -d` the container will be active again after a host reboot.