### PR TITLE
Add cmdline flag to specify network interface

### DIFF
--- a/cmd/mobius-hotline-server/main.go
+++ b/cmd/mobius-hotline-server/main.go
@@ -43,7 +43,8 @@ func main() {
 	// 	}
 	// }()
 
-	basePort := flag.Int("bind", defaultPort, "Bind address and port")
+	netInterface := flag.String("interface", "", "IP addr of interface to listen on.  Defaults to all interfaces.")
+	basePort := flag.Int("bind", defaultPort, "Base Hotline server port.  File transfer port is base port + 1.")
 	statsPort := flag.String("stats-port", "", "Enable stats HTTP endpoint on address and port")
 	configDir := flag.String("config", defaultConfigPath(), "Path to config root")
 	version := flag.Bool("version", false, "print version and exit")
@@ -96,7 +97,7 @@ func main() {
 		logger.Fatalw("Configuration directory not found.  Correct the path or re-run with -init to generate initial config.", "path", configDir)
 	}
 
-	srv, err := hotline.NewServer(*configDir, *basePort, logger, &hotline.OSFileStore{})
+	srv, err := hotline.NewServer(*configDir, *netInterface, *basePort, logger, &hotline.OSFileStore{})
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/hotline/server.go
+++ b/hotline/server.go
@@ -30,6 +30,7 @@ type requestCtx struct {
 }
 
 type Server struct {
+	NetInterface  string
 	Port          int
 	Accounts      map[string]*Account
 	Agreement     []byte
@@ -82,15 +83,15 @@ type PrivateChat struct {
 func (s *Server) ListenAndServe(ctx context.Context, cancelRoot context.CancelFunc) error {
 	s.Logger.Infow("Hotline server started",
 		"version", VERSION,
-		"API port", fmt.Sprintf(":%v", s.Port),
-		"Transfer port", fmt.Sprintf(":%v", s.Port+1),
+		"API port", fmt.Sprintf("%s:%v", s.NetInterface, s.Port),
+		"Transfer port", fmt.Sprintf("%s:%v", s.NetInterface, s.Port+1),
 	)
 
 	var wg sync.WaitGroup
 
 	wg.Add(1)
 	go func() {
-		ln, err := net.Listen("tcp", fmt.Sprintf("%s:%v", "", s.Port))
+		ln, err := net.Listen("tcp", fmt.Sprintf("%s:%v", s.NetInterface, s.Port))
 		if err != nil {
 			s.Logger.Fatal(err)
 		}
@@ -100,7 +101,7 @@ func (s *Server) ListenAndServe(ctx context.Context, cancelRoot context.CancelFu
 
 	wg.Add(1)
 	go func() {
-		ln, err := net.Listen("tcp", fmt.Sprintf("%s:%v", "", s.Port+1))
+		ln, err := net.Listen("tcp", fmt.Sprintf("%s:%v", s.NetInterface, s.Port+1))
 		if err != nil {
 			s.Logger.Fatal(err)
 		}
@@ -206,8 +207,9 @@ const (
 )
 
 // NewServer constructs a new Server from a config dir
-func NewServer(configDir string, netPort int, logger *zap.SugaredLogger, fs FileStore) (*Server, error) {
+func NewServer(configDir, netInterface string, netPort int, logger *zap.SugaredLogger, fs FileStore) (*Server, error) {
 	server := Server{
+		NetInterface:  netInterface,
 		Port:          netPort,
 		Accounts:      make(map[string]*Account),
 		Config:        new(Config),


### PR DESCRIPTION
Add command line flag to specify which network interface to listen on.  The `net.Listen` function wants this to be a string of an IP address on an interface of the host.

Example usage to listen on the interface with IP 169.254.87.101 bound and port 5600

`--interface=169.254.87.101 --bind=5600`

I'd maybe like to rename `--bind` now, but will avoid making a breaking change for now.

#116