### PR TITLE
Add support for Mac Roman character encoding

### DIFF
--- a/hotline/file_path.go
+++ b/hotline/file_path.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
@@ -119,6 +120,9 @@ func readPath(fileRoot string, filePath, fileName []byte) (fullPath string, err 
 		subPath,
 		filepath.Join("/", string(fileName)),
 	)
-
+	fullPath, err = txtDecoder.String(fullPath)
+	if err != nil {
+		return "", fmt.Errorf("invalid filepath encoding: %w", err)
+	}
 	return fullPath, nil
 }

--- a/hotline/files.go
+++ b/hotline/files.go
@@ -118,6 +118,10 @@ func getFileNameList(path string, ignoreList []string) (fields []Field, err erro
 		}
 
 		strippedName := strings.ReplaceAll(file.Name(), ".incomplete", "")
+		strippedName, err = txtEncoder.String(strippedName)
+		if err != nil {
+			return nil, err
+		}
 
 		nameSize := make([]byte, 2)
 		binary.BigEndian.PutUint16(nameSize, uint16(len(strippedName)))

--- a/hotline/server.go
+++ b/hotline/server.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"github.com/go-playground/validator/v10"
 	"go.uber.org/zap"
+	"golang.org/x/text/encoding/charmap"
 	"gopkg.in/yaml.v3"
 	"io"
 	"io/fs"
@@ -28,6 +29,12 @@ var contextKeyReq = contextKey("req")
 type requestCtx struct {
 	remoteAddr string
 }
+
+// Converts bytes from Mac Roman encoding to UTF-8
+var txtDecoder = charmap.Macintosh.NewDecoder()
+
+// Converts bytes from UTF-8 to Mac Roman encoding
+var txtEncoder = charmap.Macintosh.NewEncoder()
 
 type Server struct {
 	NetInterface  string


### PR DESCRIPTION
Add support for [Mac Roman](https://en.wikipedia.org/wiki/Mac_OS_Roman) character encoding.  

Incoming strings from the client will be assumed to be Mac Roman encoding instead of ASCII and converted to UTF-8.

Outgoing strings will be converted from UTF-8 to Mac Roman.

Mac Client:
<img width="311" alt="Screenshot 2024-04-04 at 3 44 11 PM" src="https://github.com/jhalter/mobius/assets/868228/d2d73241-c045-4048-a63b-2ca84a861f15">

Server file system:
```
❯ ls
HéLLø                   My Cool Stuff ƒ
```