### PR TITLE
If no predefined default path for server config, look in the current dir

### DIFF
--- a/cmd/mobius-hotline-server/main.go
+++ b/cmd/mobius-hotline-server/main.go
@@ -182,7 +182,7 @@ func defaultConfigPath() (cfgPath string) {
 	case "linux":
 		cfgPath = "/usr/local/var/mobius/config/"
 	default:
-		fmt.Printf("unsupported OS")
+		cfgPath = "./config/"
 	}
 
 	return cfgPath


### PR DESCRIPTION
This was the only change I needed to make in order to hit the ground running with a Hotline server on NetBSD. I'll admit that I haven't validated every code path to ensure NetBSD makes a fully-featured Mobius host, but I was able to get from zero to 60 with nothing but this.

Given just how much functionality this change has enabled in my testing, I kinda expect it would also enable FreeBSD, OpenBSD, DragonFly and perhaps every other platform supported by Go to Just Work, too.