### PR TITLE
Ignore files with incompatible names

### DIFF
--- a/hotline/files.go
+++ b/hotline/files.go
@@ -123,7 +123,7 @@ func getFileNameList(path string, ignoreList []string) (fields []Field, err erro
 		strippedName := strings.ReplaceAll(file.Name(), ".incomplete", "")
 		strippedName, err = txtEncoder.String(strippedName)
 		if err != nil {
-			return nil, err
+			continue
 		}
 
 		nameSize := make([]byte, 2)


### PR DESCRIPTION
Ignore files with incompatible names that cannot be translated to Mac OS Roman encoding instead of completely failing the "Get File List" transaction.