### PR TITLE
Fix corrupt file info forks

### DIFF
--- a/hotline/file_wrapper.go
+++ b/hotline/file_wrapper.go
@@ -114,7 +114,7 @@ func (f *fileWrapper) rsrcForkWriter() (io.WriteCloser, error) {
 }
 
 func (f *fileWrapper) infoForkWriter() (io.WriteCloser, error) {
-	file, err := os.OpenFile(f.infoPath, os.O_CREATE|os.O_WRONLY, 0644)
+	file, err := os.OpenFile(f.infoPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This fixes a bug that happens when:

1. Optional "Enable Resource Forks" feature is true
2. A file comment is added
3. The comment is updated to be shorter than the original

The expected behavior is that the hidden .info file is replaced with the new data, but this wasn't happening because the file flag was not set to truncate on write.