### PR TITLE
Add initial HTTP API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,3 +171,62 @@ Usage of mobius-hotline-server:
 
 To run as a systemd service, refer to this sample unit file: [mobius-hotline-server.service](https://github.com/jhalter/mobius/blob/master/cmd/mobius-hotline-server/mobius-hotline-server.service)
 
+## (Optional) HTTP API
+
+The Mobius server includes an optional HTTP API to perform out-of-band administrative functions.
+
+To enable it, include the `--api-port` flag with a string defining the IP and port to listen on in the form of `<ip>:<port>`.
+
+Example: `--api-port=127.0.0.1:5503`
+
+⚠️ The API has no authentication, so binding it to localhost is a good idea!
+
+#### GET /api/v1/stats
+
+The stats endpoint returns server runtime statistics and counters.
+
+```
+❯ curl -s localhost:5603/api/v1/stats  | jq .
+{
+  "ConnectionCounter": 0,
+  "ConnectionPeak": 0,
+  "CurrentlyConnected": 0,
+  "DownloadCounter": 0,
+  "DownloadsInProgress": 0,
+  "Since": "2024-07-18T15:36:42.426156-07:00",
+  "UploadCounter": 0,
+  "UploadsInProgress": 0,
+  "WaitingDownloads": 0
+}
+```
+
+#### GET /api/v1/reload
+
+The reload endpoint reloads the following configuration files from disk:
+
+* Agreement.txt
+* News.txt
+* Users/*.yaml
+* ThreadedNews.yaml
+* banner.jpg
+
+Example:
+
+```
+❯ curl -s localhost:5603/api/v1/reload | jq .
+{
+  "msg": "config reloaded"
+}
+```
+
+#### POST /api/v1/shutdown
+
+The shutdown endpoint accepts a shutdown message from POST payload, sends it to to all connected Hotline clients, then gracefully shuts down the server.
+
+Example:
+
+```
+❯ curl -d 'Server rebooting' localhost:5603/api/v1/shutdown
+
+{ "msg": "server shutting down" }
+```

--- a/internal/mobius/api.go
+++ b/internal/mobius/api.go
@@ -1,0 +1,96 @@
+package mobius
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/jhalter/mobius/hotline"
+	"io"
+	"log"
+	"log/slog"
+	"net/http"
+)
+
+type logResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+	buf        bytes.Buffer
+}
+
+func NewLogResponseWriter(w http.ResponseWriter) *logResponseWriter {
+	return &logResponseWriter{w, http.StatusOK, bytes.Buffer{}}
+}
+
+func (lrw *logResponseWriter) WriteHeader(code int) {
+	lrw.statusCode = code
+	lrw.ResponseWriter.WriteHeader(code)
+}
+
+func (lrw *logResponseWriter) Write(b []byte) (int, error) {
+	lrw.buf.Write(b)
+	return lrw.ResponseWriter.Write(b)
+}
+
+type APIServer struct {
+	hlServer *hotline.Server
+	logger   *slog.Logger
+	mux      *http.ServeMux
+}
+
+func (srv *APIServer) logMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lrw := NewLogResponseWriter(w)
+		next.ServeHTTP(lrw, r)
+
+		srv.logger.Info("req", "method", r.Method, "url", r.URL.Path, "remoteAddr", r.RemoteAddr, "response_code", lrw.statusCode)
+	})
+}
+
+func NewAPIServer(hlServer *hotline.Server, reloadFunc func(), logger *slog.Logger) *APIServer {
+	srv := APIServer{
+		hlServer: hlServer,
+		logger:   logger,
+		mux:      http.NewServeMux(),
+	}
+
+	srv.mux.Handle("/api/v1/reload", srv.logMiddleware(http.HandlerFunc(srv.ReloadHandler(reloadFunc))))
+	srv.mux.Handle("/api/v1/shutdown", srv.logMiddleware(http.HandlerFunc(srv.ShutdownHandler)))
+	srv.mux.Handle("/api/v1/stats", srv.logMiddleware(http.HandlerFunc(srv.RenderStats)))
+
+	return &srv
+}
+
+func (srv *APIServer) ShutdownHandler(w http.ResponseWriter, r *http.Request) {
+	msg, err := io.ReadAll(r.Body)
+	if err != nil || len(msg) == 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	go srv.hlServer.Shutdown(msg)
+
+	_, _ = io.WriteString(w, `{ "msg": "server shutting down" }`)
+}
+
+func (srv *APIServer) ReloadHandler(reloadFunc func()) func(w http.ResponseWriter, _ *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		reloadFunc()
+
+		_, _ = io.WriteString(w, `{ "msg": "config reloaded" }`)
+	}
+}
+
+func (srv *APIServer) RenderStats(w http.ResponseWriter, _ *http.Request) {
+	u, err := json.Marshal(srv.hlServer.CurrentStats())
+	if err != nil {
+		panic(err)
+	}
+
+	_, _ = io.WriteString(w, string(u))
+}
+
+func (srv *APIServer) Serve(port string) {
+	err := http.ListenAndServe(port, srv.mux)
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
This replaces the `--stat-port` flag and HTTP endpoint with a new `--api-addr` flag, with a couple of additional administrative endpoints to provide functionality  present in the original Hotline server UI but missing in Mobius.

* `POST /api/v1/shutdown - sends message to connected clients and shuts down the server`
* `GET /api/v1/reload- reloads the configuration files from disk`
* `GET /api/v1/stats` - returns server runtime statistics and counters.

Fixes #4
