### PR TITLE
Implement “Customized files for users” feature

### DIFF
--- a/hotline/account.go
+++ b/hotline/account.go
@@ -15,6 +15,7 @@ type Account struct {
 	Name     string       `yaml:"Name"`
 	Password string       `yaml:"Password"`
 	Access   AccessBitmap `yaml:"Access,flow"`
+	FileRoot string       `yaml:"FileRoot"`
 
 	readOffset int // Internal offset to track read progress
 }

--- a/hotline/client_conn.go
+++ b/hotline/client_conn.go
@@ -42,6 +42,13 @@ type ClientConn struct {
 	mu sync.RWMutex
 }
 
+func (cc *ClientConn) FileRoot() string {
+	if cc.Account.FileRoot != "" {
+		return cc.Account.FileRoot
+	}
+	return cc.Server.Config.FileRoot
+}
+
 type ClientFileTransferMgr struct {
 	transfers map[FileTransferType]map[FileTransferID]*FileTransfer
 

--- a/hotline/file_transfer.go
+++ b/hotline/file_transfer.go
@@ -87,6 +87,7 @@ func (ftm *MemFileTransferMgr) Delete(id FileTransferID) {
 }
 
 type FileTransfer struct {
+	FileRoot         string
 	FileName         []byte
 	FilePath         []byte
 	RefNum           [4]byte
@@ -116,9 +117,10 @@ func (wc *WriteCounter) Write(p []byte) (int, error) {
 	return n, nil
 }
 
-func (cc *ClientConn) NewFileTransfer(transferType FileTransferType, fileName, filePath, size []byte) *FileTransfer {
+func (cc *ClientConn) NewFileTransfer(transferType FileTransferType, fileroot string, fileName, filePath, size []byte) *FileTransfer {
 	ft := &FileTransfer{
 		FileName:         fileName,
+		FileRoot:         fileroot,
 		FilePath:         filePath,
 		Type:             transferType,
 		TransferSize:     size,

--- a/hotline/server.go
+++ b/hotline/server.go
@@ -526,7 +526,7 @@ func (s *Server) handleFileTransfer(ctx context.Context, rwc io.ReadWriter) erro
 		"Name", string(fileTransfer.ClientConn.UserName),
 	)
 
-	fullPath, err := ReadPath(s.Config.FileRoot, fileTransfer.FilePath, fileTransfer.FileName)
+	fullPath, err := ReadPath(fileTransfer.FileRoot, fileTransfer.FilePath, fileTransfer.FileName)
 	if err != nil {
 		return err
 	}
@@ -534,7 +534,7 @@ func (s *Server) handleFileTransfer(ctx context.Context, rwc io.ReadWriter) erro
 	switch fileTransfer.Type {
 	case BannerDownload:
 		if _, err := io.Copy(rwc, bytes.NewBuffer(s.Banner)); err != nil {
-			return fmt.Errorf("error sending Banner: %w", err)
+			return fmt.Errorf("banner download: %w", err)
 		}
 	case FileDownload:
 		s.Stats.Increment(StatDownloadCounter, StatDownloadsInProgress)
@@ -555,7 +555,7 @@ func (s *Server) handleFileTransfer(ctx context.Context, rwc io.ReadWriter) erro
 
 		err = UploadHandler(rwc, fullPath, fileTransfer, s.FS, rLogger, s.Config.PreserveResourceForks)
 		if err != nil {
-			return fmt.Errorf("file upload error: %w", err)
+			return fmt.Errorf("file upload: %w", err)
 		}
 
 	case FolderDownload:
@@ -566,7 +566,7 @@ func (s *Server) handleFileTransfer(ctx context.Context, rwc io.ReadWriter) erro
 
 		err = DownloadFolderHandler(rwc, fullPath, fileTransfer, s.FS, rLogger, s.Config.PreserveResourceForks)
 		if err != nil {
-			return fmt.Errorf("file upload error: %w", err)
+			return fmt.Errorf("folder download: %w", err)
 		}
 
 	case FolderUpload:
@@ -584,7 +584,7 @@ func (s *Server) handleFileTransfer(ctx context.Context, rwc io.ReadWriter) erro
 
 		err = UploadFolderHandler(rwc, fullPath, fileTransfer, s.FS, rLogger, s.Config.PreserveResourceForks)
 		if err != nil {
-			return fmt.Errorf("file upload error: %w", err)
+			return fmt.Errorf("folder upload: %w", err)
 		}
 	}
 	return nil

--- a/hotline/server_test.go
+++ b/hotline/server_test.go
@@ -99,12 +99,7 @@ func TestServer_handleFileTransfer(t *testing.T) {
 		{
 			name: "file download",
 			fields: fields{
-				FS: &OSFileStore{},
-				Config: Config{
-					FileRoot: func() string {
-						path, _ := os.Getwd()
-						return path + "/test/config/Files"
-					}()},
+				FS:     &OSFileStore{},
 				Logger: NewTestLogger(),
 				Stats:  NewStats(),
 				FileTransferMgr: &MemFileTransferMgr{
@@ -114,6 +109,10 @@ func TestServer_handleFileTransfer(t *testing.T) {
 							Type:     FileDownload,
 							FileName: []byte("testfile-8b"),
 							FilePath: []byte{},
+							FileRoot: func() string {
+								path, _ := os.Getwd()
+								return path + "/test/config/Files"
+							}(),
 							ClientConn: &ClientConn{
 								Account: &Account{
 									Login: "foo",

--- a/internal/mobius/transaction_handlers_test.go
+++ b/internal/mobius/transaction_handlers_test.go
@@ -782,7 +782,8 @@ func TestHandleGetFileInfo(t *testing.T) {
 			name: "returns expected fields when a valid file is requested",
 			args: args{
 				cc: &hotline.ClientConn{
-					ID: [2]byte{0x00, 0x01},
+					ID:      [2]byte{0, 1},
+					Account: &hotline.Account{},
 					Server: &hotline.Server{
 						FS: &hotline.OSFileStore{},
 						Config: hotline.Config{
@@ -2629,14 +2630,13 @@ func TestHandleGetFileNameList(t *testing.T) {
 			name: "with file root",
 			args: args{
 				cc: &hotline.ClientConn{
-					Server: &hotline.Server{
-						Config: hotline.Config{
-							FileRoot: func() string {
-								path, _ := os.Getwd()
-								return filepath.Join(path, "/test/config/Files/getFileNameListTestDir")
-							}(),
-						},
+					Account: &hotline.Account{
+						FileRoot: func() string {
+							path, _ := os.Getwd()
+							return filepath.Join(path, "/test/config/Files/getFileNameListTestDir")
+						}(),
 					},
+					Server: &hotline.Server{},
 				},
 				t: hotline.NewTransaction(
 					hotline.TranGetFileNameList, [2]byte{0, 1},


### PR DESCRIPTION
The official Hotline Server has a feature to override the files that a user account sees by putting a folder or alias called "Files" in the user account directory.

To provide equivalent functionality in Mobius, this change adds support for an optional FileRoot in the user account yaml files under  `config/Users/*`

Example: 
```
FileRoot: /foo/bar/baz
```

Fixes #30 